### PR TITLE
Add script and docs to import Codex WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Codex Universal WSL Builder
+
+This repository provides scripts and instructions for building or installing a WSL distribution that mirrors the ChatGPT Codex environment.
+
+A Docker based build script is included for creating a root filesystem tarball from the public [openai/codex-universal](https://github.com/openai/codex-universal) repository.  For convenience on Windows, a separate script imports the latest GitHub release directly using `wsl.exe` from a Cygwin shell.
+
+## Requirements
+
+- Docker (for building the rootfs)
+- Git
+- On Windows: Cygwin with `curl` and access to the `wsl.exe` command
+
+## Building the Rootfs
+
+Run the build script from any Unix environment with Docker installed:
+
+```bash
+./build_codex_wsl.sh
+```
+
+This clones `openai/codex-universal` if needed, builds the Docker image, exports a container filesystem, and injects environment initialization files so that the resulting `codex-wsl-rootfs.tar.gz` behaves like the Codex shell.
+
+## Installing on Windows
+
+From a Cygwin terminal, execute the installer script which downloads the binary release and uses `wsl.exe` to import the distribution:
+
+```bash
+./create_codex_wsl.sh
+```
+
+By default the distribution is imported as `CodexEnv` under `~/CodexEnv`. Pass `DISTRO_NAME` and `INSTALL_DIR` environment variables to override these paths.
+
+## Environment Details
+
+Initialization follows the order described in `Codex-Shell-Execution-Order.md`.  Docker `ENV` variables and typical `CODEX_ENV_*` values are written to `/etc/profile.d/codex_env.sh` inside the distribution so they are available whenever the shell starts.

--- a/build_codex_wsl.sh
+++ b/build_codex_wsl.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build script for a WSL rootfs replicating the ChatGPT Codex environment.
+# It clones the codex-universal repository, builds the Docker image, exports
+# the container filesystem, and injects environment initialization files so
+# that the resulting tarball can be imported directly with `wsl`.
+
+REPO_URL="https://github.com/openai/codex-universal.git"
+REPO_DIR="codex-universal"
+IMAGE_NAME="codex-universal-wsl"
+ROOTFS_TAR="codex-wsl-rootfs.tar"
+
+# Clone the upstream repository if it doesn't already exist
+if [ ! -d "$REPO_DIR" ]; then
+    git clone "$REPO_URL" "$REPO_DIR"
+fi
+
+# Build the Docker image containing the Codex environment
+cd "$REPO_DIR"
+docker build -t "$IMAGE_NAME" .
+cd - >/dev/null
+
+# Create a container from the image and export its filesystem
+CID=$(docker create "$IMAGE_NAME" /bin/bash)
+docker export "$CID" -o "$ROOTFS_TAR"
+docker rm "$CID"
+
+# Inject environment variables and setup script sourcing
+TMPDIR=$(mktemp -d)
+tar -xf "$ROOTFS_TAR" -C "$TMPDIR"
+mkdir -p "$TMPDIR/etc/profile.d"
+cat > "$TMPDIR/etc/profile.d/codex_env.sh" <<'EOS'
+export LANG=${LANG:-C.UTF-8}
+export LC_ALL=${LC_ALL:-C.UTF-8}
+export CODEX_ENV_PYTHON_VERSION=${CODEX_ENV_PYTHON_VERSION:-3.12}
+export CODEX_ENV_NODE_VERSION=${CODEX_ENV_NODE_VERSION:-20}
+export CODEX_ENV_RUBY_VERSION=${CODEX_ENV_RUBY_VERSION:-3.4.4}
+export CODEX_ENV_RUST_VERSION=${CODEX_ENV_RUST_VERSION:-1.87.0}
+export CODEX_ENV_GO_VERSION=${CODEX_ENV_GO_VERSION:-1.24.3}
+export CODEX_ENV_BUN_VERSION=${CODEX_ENV_BUN_VERSION:-1.2.14}
+export CODEX_ENV_JAVA_VERSION=${CODEX_ENV_JAVA_VERSION:-21}
+export CODEX_ENV_SWIFT_VERSION=${CODEX_ENV_SWIFT_VERSION:-6.1}
+
+if [ -f /opt/codex/setup_universal.sh ]; then
+    source /opt/codex/setup_universal.sh
+fi
+EOS
+
+tar -C "$TMPDIR" -cf "$ROOTFS_TAR" .
+rm -rf "$TMPDIR"
+
+gzip -f "$ROOTFS_TAR"
+
+echo "Created $(pwd)/${ROOTFS_TAR}.gz"

--- a/create_codex_wsl.sh
+++ b/create_codex_wsl.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script for Cygwin to download the latest Codex WSL rootfs release and import it
+# using the Windows `wsl` command.
+
+RELEASE_URL=${RELEASE_URL:-"https://github.com/openai/codex-universal/releases/latest/download/codex-wsl-rootfs.tar.gz"}
+DISTRO_NAME=${DISTRO_NAME:-CodexEnv}
+INSTALL_DIR=${INSTALL_DIR:-"$HOME/$DISTRO_NAME"}
+TARBALL="codex-wsl-rootfs.tar.gz"
+
+# Download the release tarball
+curl -L -o "$TARBALL" "$RELEASE_URL"
+
+# Import the distribution via wsl.exe
+mkdir -p "$INSTALL_DIR"
+wsl.exe --import "$DISTRO_NAME" "$(cygpath -w "$INSTALL_DIR")" "$(cygpath -w "$TARBALL")" --version 2
+
+echo "Imported WSL distribution '$DISTRO_NAME'"


### PR DESCRIPTION
## Summary
- inject Codex env variables when building the WSL rootfs
- provide `create_codex_wsl.sh` for installing on Windows via Cygwin
- document build and install steps with environment details

## Testing
- `bash -n build_codex_wsl.sh`
- `bash -n create_codex_wsl.sh`


------
https://chatgpt.com/codex/tasks/task_b_68742fd5963083268dcb028a6763f914