### PR TITLE
Document rootfs overlay in build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Codex Universal WSL
+
+This repository packages the [openai/codex-universal](https://github.com/openai/codex-universal) image into a
+WSL distributable. The `rootfs` directory contains configuration files that
+mirror the environment of the Codex Environment Editor.
+
+## Prerequisites
+
+* Initialize the `codex-universal` submodule:
+
+```bash
+git submodule update --init --depth 1
+```
+
+The submodule provides the base filesystem used to build the WSL tarball.
+
+## Building the WSL Distribution
+
+Run the build script to generate a tarball that can be imported with `wsl.exe`:
+
+```bash
+./build-wsl-distro.sh
+```
+
+The script creates `codex-universal-wsl.tar.gz` in the project root.  Files
+under `rootfs/` are overlaid on top of the vanilla
+`openai/codex-universal` filesystem from the submodule, ensuring that any
+custom configuration in this repository becomes part of the resulting WSL
+distro.
+
+Import the tarball on Windows using:
+
+```powershell
+wsl --import CodexUniversal <install-path> .\codex-universal-wsl.tar.gz
+```
+

--- a/build-wsl-distro.sh
+++ b/build-wsl-distro.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Build a WSL-compatible Codex distro tarball.
+# This script assumes the `codex-universal` submodule is initialized.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_REPO="$ROOT_DIR/codex-universal"
+OVERLAY_DIR="$ROOT_DIR/rootfs"
+OUTPUT_DIR="$ROOT_DIR/build/rootfs"
+TARBALL="$ROOT_DIR/codex-universal-wsl.tar.gz"
+
+if [ ! -d "$BASE_REPO" ]; then
+    echo "codex-universal submodule not found. Run 'git submodule update --init --depth 1'" >&2
+    exit 1
+fi
+
+# Prepare output directory
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# Copy base filesystem
+if [ -d "$BASE_REPO/rootfs" ]; then
+    cp -a "$BASE_REPO/rootfs/." "$OUTPUT_DIR/"
+fi
+
+# Overlay custom rootfs files
+cp -a "$OVERLAY_DIR/." "$OUTPUT_DIR/"
+
+# Create tarball
+rm -f "$TARBALL"
+tar --numeric-owner -C "$OUTPUT_DIR" -czf "$TARBALL" .
+
+echo "WSL distro created: $TARBALL"


### PR DESCRIPTION
## Summary
- clarify that files in `rootfs/` are included in the WSL tarball
- preserve numeric user IDs when creating the archive

## Testing
- `bash -n build-wsl-distro.sh`
- `./build-wsl-distro.sh` *(fails: codex-universal submodule not found)*

------
https://chatgpt.com/codex/tasks/task_b_68744e5ee12c8326be5e143290cf6652