### PR TITLE
Fix pyenv lookup on login

### DIFF
--- a/rootfs/etc/profile
+++ b/rootfs/etc/profile
@@ -25,10 +25,3 @@ if [ -d /etc/profile.d ]; then
   done
   unset i
 fi
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init - bash)"
-source $NVM_DIR/nvm.sh
-export BUN_INSTALL=/root/.bun
-export PATH="$BUN_INSTALL/bin:$PATH"
-. ~/.local/share/swiftly/env.sh


### PR DESCRIPTION
## Summary
- remove pyenv/nvm/bun setup lines from `/etc/profile`
- rely on existing `/etc/profile.d/02-codex-dockerfile-env.sh` for runtime setup

This ensures `pyenv` is available before `setup_universal.sh` runs.

## Testing
- `bash -n rootfs/etc/profile`

------
https://chatgpt.com/codex/tasks/task_b_687490da418c8326a4ca06ab20cc3828